### PR TITLE
Fix index.html subdirectory rendering and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,13 @@ Easily deploy your HTTPS-enabled, S3-backed Hugo blogs!
 1. Ensure that your repository conforms to [Hugo's standards](https://gohugo.io/getting-started/directory-structure/).
 2. Clone this repository.
 3. Create an environment file: `make create_env`. Fill in the values shown in the
-   newly-created `.env` file.
+   newly-created `.env` file. You can also fetch this from S3c
 4. Deploy your blog: `make deploy`.
+
+# Required environment variables (outside of .env)
+
+# Environment variables that you can optionally set
+
+- *`DOTENV_S3_BUCKET`*: Define this to fetch your environment file from S3.
+  You will also need to define `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+  and `AWS_REGION`.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,35 @@ Easily deploy your HTTPS-enabled, S3-backed Hugo blogs!
    newly-created `.env` file. You can also fetch this from S3c
 4. Deploy your blog: `make deploy`.
 
-# Required environment variables (outside of .env)
+# Using this with CI
 
-# Environment variables that you can optionally set
+If you're using this to continuously deploy your blog, do the following before
+having your builder clone this repository:
 
-- *`DOTENV_S3_BUCKET`*: Define this to fetch your environment file from S3.
-  You will also need to define `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-  and `AWS_REGION`.
+- Remove any `docker-compose.yml` and `Makefile` files present at the root
+  of your directory: `rm -f docker-compose.yml Makefile`
+
+# Remote environment files
+
+You can fetch remote environment dotfiles by using special environment variables
+or an `.env_info` file in the toplevel of your repository. Supported backends
+are documented below.
+
+## S3
+
+To fetch environment variables from a S3 bucket, define `DOTENV_S3_BUCKET` or
+specify the bucket containing your dotfiles in `.env_info`. Note that you will
+also need to specify an AWS `.credentials` file or define `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY` and `AWS_REGION` for this to work.
+
+# Using a CDN
+
+This blog generator can create a content delivery network for you for your
+readers to enjoy consistently-fast access to your blog from anywhere in the world.
+Supported providers are defined below.
+
+**NOTE**: *This might cost you money!*
+
+## CloudFront
+
+To enable AWS CloudFront, set `ENABLE_CLOUDFRONT_CDN` in your `.env` to `true`.

--- a/infrastructure/aws/cdn.tf
+++ b/infrastructure/aws/cdn.tf
@@ -8,7 +8,7 @@ resource "aws_cloudfront_distribution" "blog" {
   tags = "${local.default_tags}"
   aliases = [ "${local.blog_fqdn_requested}" ]
   origin {
-    domain_name =  "${aws_s3_bucket.blog.bucket_regional_domain_name}"
+    domain_name = "${aws_s3_bucket.blog.website_endpoint}"
     origin_id = "${local.s3_bucket_origin_id}"
     s3_origin_config {
       origin_access_identity = "${aws_cloudfront_origin_access_identity.blog_access.cloudfront_access_identity_path}"


### PR DESCRIPTION
We need index.html files in post subdirectories to be retrieved automatically
whenever we go to the post's stub link.

Example:

```
A post at `posts/test_post.md` will be generated as `site/contents/posts/test_post/index.html`.
When I browse `https://blog.carlosnunez.me/posts/test_post`
I should be taken to `https://blog.carlosnunez.me/posts/test_post/index.html`
and it should show up as `https://blog.carlosnunez.me/posts/test_post` in my browser's address bar.
```