### PR TITLE
Enable blogs to be rendered locally with bloggen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+.env
+.env.*
+!.env.test
+!.env.example
+site/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM alpine
-ARG HUGO_VERSION
-ENV HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
-ADD $HUGO_URL /tmp/hugo.tar.gz
-RUN tar -xvf /tmp/hugo.tar.gz -C /usr/bin/
-ENTRYPOINT [ "hugo" ]
+MAINTAINER Carlos Nunez <dev@carlosnunez.me>
+
+COPY . /app
+RUN apk add --no-cache bash make git docker py-pip && \
+  pip install docker-compose && \
+  rm -rf .env .git
+
+ENTRYPOINT [ "make" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,45 @@ having your builder clone this repository:
 - Remove any `docker-compose.yml` and `Makefile` files present at the root
   of your directory: `rm -f docker-compose.yml Makefile`
 
+# Rendering your blog locally
+
+## Without Docker
+
+To render your blog locally, use this Make command: `make start_local_blog`.
+
+## With Docker
+
+1. Clone this repository: `git clone https://github.com/carlosonunez/https-hugo-bloggen`
+2. Build the Docker image within: `docker build -t bloggen https-hugo-bloggen`
+3. Run `make start_local_blog`, but export your working directory with the
+   `HOST_PWD` environment variable so that nested containers know where to 
+   find your contents:
+
+   ```bash
+   docker run -e HOST_PWD=$PWD \
+    -v "$PWD/https-hugo-bloggen:/app" \
+    -v "$PWD/posts:/app/posts" \
+    -v "$PWD/layouts:/app/layouts" \
+    -v "$PWD/static:/app/static" \
+    -v "$PWD/config.toml.tmpl:/app/config.toml.tmpl" \
+    -w /app \
+    -p 8080:8080 \
+    --net host \
+    --name blog \
+    bloggen start_local_blog
+  ```
+
+*NOTE*: You might find it easier to use Docker Compose for this. Also, consider
+adding `https-hugo-bloggen` to your `.gitignore` if you intend on always
+using the latest version.
+
+*NOTE*: `--net=host` is required so that the port allocated by the nested
+Hugo container is made accessible to your host. If you are using 8080 for
+something else, choose another port.
+
+*NOTE*: To see the directory structure created by Hugo, use this command:
+`docker exec -it blog sh -c "ls /app/site"`
+
 # Remote environment files
 
 You can fetch remote environment dotfiles by using special environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   travis-ci:
     image: skandyla/travis-cli
     volumes:
-      - "$PWD:/work"
+      - "$HOST_PWD:/work"
     working_dir: /work
     environment:
       - TRAVIS_GITHUB_TOKEN
@@ -15,7 +15,7 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_REGION
     volumes:
-      - "${PWD}:/work"
+      - "${HOST_PWD}:/work"
 
   gomplate:
     image: hairyhenderson/gomplate
@@ -29,18 +29,18 @@ services:
       context: .
     tty: true
     volumes:
-      - "${PWD}/site:/site"
-      - "${PWD}/posts/:/site/content/post"
-      - "${PWD}/layouts/:/site/layouts"
-      - "${PWD}/themes/:/site/themes"
-      - "${PWD}/static/:/site/static"
-      - "${PWD}/config.toml:/site/config.toml"
+      - "${HOST_PWD}/site:/site"
+      - "${HOST_PWD}/posts/:/site/content/post"
+      - "${HOST_PWD}/layouts/:/site/layouts"
+      - "${HOST_PWD}/themes/:/site/themes"
+      - "${HOST_PWD}/static/:/site/static"
+      - "${HOST_PWD}/config.toml:/site/config.toml"
     working_dir: /site
 
   terraform:
     image: hashicorp/terraform:0.11.10
     volumes:
-      - "${PWD}/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "${HOST_PWD}/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
     working_dir: /work
     env_file: .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
 
   hugo:
     build:
+      dockerfile: hugo.dockerfile
       args:
         - HUGO_VERSION=0.49
       context: .

--- a/hugo.dockerfile
+++ b/hugo.dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+ARG HUGO_VERSION
+ENV HUGO_URL=https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
+ADD $HUGO_URL /tmp/hugo.tar.gz
+RUN tar -xvf /tmp/hugo.tar.gz -C /usr/bin/
+ENTRYPOINT [ "hugo" ]

--- a/include/compose/dotenv.yml
+++ b/include/compose/dotenv.yml
@@ -6,7 +6,7 @@ services:
       - ENVIRONMENT_NAME
       - S3_BUCKET
     volumes:
-      - $PWD:/work
+      - $HOST_PWD:/work
     command: s3 cp s3://${S3_BUCKET}/${ENVIRONMENT_NAME}/.env /work/.env
 
   upload-dotenv-file-to-s3:
@@ -15,7 +15,7 @@ services:
       - ENVIRONMENT_NAME
       - S3_BUCKET
     volumes:
-      - $PWD:/work
+      - $HOST_PWD:/work
     entrypoint: 
       - sh
       - "-c"

--- a/include/compose/hugo.yml
+++ b/include/compose/hugo.yml
@@ -17,6 +17,8 @@ services:
   hugo-server:
     extends: hugo
     env_file: .env
+    ports:
+      - 8080:8080
     depends_on:
       - generate-hugo-configs
     command:

--- a/include/compose/hugo.yml
+++ b/include/compose/hugo.yml
@@ -3,7 +3,7 @@ services:
   fetch-hugo-theme:
     image: alpine/git
     volumes:
-      - "$PWD:/work"
+      - "$HOST_PWD:/work"
     working_dir: /work
     env_file: .env
     environment:
@@ -37,8 +37,8 @@ services:
     depends_on:
       - generate-hugo-test-configs
     volumes:
-      - "${PWD}/tests/fixtures/test_posts/:/site/content/post"
-      - "${PWD}/tests/fixtures/test_themes/:/site/themes"
+      - "${HOST_PWD}/tests/fixtures/test_posts/:/site/content/post"
+      - "${HOST_PWD}/tests/fixtures/test_themes/:/site/themes"
     command:
       - server
       - --baseURL
@@ -59,7 +59,7 @@ services:
     links:
       - hugo-test-server:hugo
     volumes:
-      - "${PWD}/tests:/tests"
+      - "${HOST_PWD}/tests:/tests"
     command: /tests/unit
 
   hugo-integration-tests:
@@ -68,7 +68,7 @@ services:
     environment:
       - BLOG_URL
     volumes:
-      - "${PWD}/tests:/tests"
+      - "${HOST_PWD}/tests:/tests"
     command: /tests/integration
 
   hugo-production-tests:
@@ -78,14 +78,14 @@ services:
       - BLOG_URL
       - CDN_URL
     volumes:
-      - "${PWD}/tests:/tests"
+      - "${HOST_PWD}/tests:/tests"
     command: /tests/production
 
   generate-hugo-configs:
     extends: gomplate
     env_file: .env
     volumes:
-      - "${PWD}:/work"
+      - "${HOST_PWD}:/work"
     working_dir: /work
     command:
       - "--file"
@@ -97,7 +97,7 @@ services:
     extends: gomplate
     env_file: .env.test
     volumes:
-      - "${PWD}:/work"
+      - "${HOST_PWD}:/work"
     working_dir: /work
     command:
       - "--file"

--- a/include/compose/terraform.yml
+++ b/include/compose/terraform.yml
@@ -4,8 +4,8 @@ services:
     extends: gomplate
     env_file: .env
     volumes:
-      - "$PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
-      - "$PWD/.env:/.env"
+      - "$HOST_PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "$HOST_PWD/.env:/.env"
     working_dir: /work
     command:
       - "--file"
@@ -17,8 +17,8 @@ services:
     extends: gomplate
     env_file: .env
     volumes:
-      - "$PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
-      - "$PWD/.env:/.env"
+      - "$HOST_PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "$HOST_PWD/.env:/.env"
     working_dir: /work
     command:
       - "--file"
@@ -30,8 +30,8 @@ services:
     extends: gomplate
     env_file: .env
     volumes:
-      - "$PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
-      - "$PWD/.env:/.env"
+      - "$HOST_PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "$HOST_PWD/.env:/.env"
     working_dir: /work
     command:
       - "--file"
@@ -43,8 +43,8 @@ services:
     extends: gomplate
     env_file: .env.test
     volumes:
-      - "$PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
-      - "$PWD/.env.test:/.env"
+      - "$HOST_PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "$HOST_PWD/.env.test:/.env"
     working_dir: /work
     command:
       - "--file"
@@ -54,8 +54,8 @@ services:
 
   generate-terraform-unit-test-backend:
     volumes:
-      - "$PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
-      - "$PWD/tests:/tests"
+      - "$HOST_PWD/infrastructure/${INFRASTRUCTURE_PROVIDER}:/work"
+      - "$HOST_PWD/tests:/tests"
     image: alpine
     entrypoint: "sh -c 'cp /tests/fixtures/backend.tf /work/backend.tf && touch /work/backend.tfvars'"
 

--- a/include/make/docker.mk
+++ b/include/make/docker.mk
@@ -1,5 +1,5 @@
 #!/usr/bin/env make
-EXPANDED_DOCKER_COMPOSE_COMMAND := docker-compose -f docker-compose.yml $(shell for file in include/compose/*.yml; do echo "-f $$file"; done)
+EXPANDED_DOCKER_COMPOSE_COMMAND := HOST_PWD=$(PWD) docker-compose -f docker-compose.yml $(shell for file in include/compose/*.yml; do echo "-f $$file"; done)
 DOCKER_COMPOSE_COMMAND := $(EXPANDED_DOCKER_COMPOSE_COMMAND) --log-level CRITICAL
 ifeq ($(SHOW_DOCKER_COMPOSE_LOGS),true)
 DOCKER_COMPOSE_COMMAND := $(EXPANDED_DOCKER_COMPOSE_COMMAND) --log-level INFO

--- a/include/make/docker.mk
+++ b/include/make/docker.mk
@@ -1,5 +1,6 @@
 #!/usr/bin/env make
-EXPANDED_DOCKER_COMPOSE_COMMAND := HOST_PWD=$(PWD) docker-compose -f docker-compose.yml $(shell for file in include/compose/*.yml; do echo "-f $$file"; done)
+HOST_PWD ?= $(shell pwd)
+EXPANDED_DOCKER_COMPOSE_COMMAND := HOST_PWD=$(HOST_PWD) docker-compose -f docker-compose.yml $(shell for file in include/compose/*.yml; do echo "-f $$file"; done)
 DOCKER_COMPOSE_COMMAND := $(EXPANDED_DOCKER_COMPOSE_COMMAND) --log-level CRITICAL
 ifeq ($(SHOW_DOCKER_COMPOSE_LOGS),true)
 DOCKER_COMPOSE_COMMAND := $(EXPANDED_DOCKER_COMPOSE_COMMAND) --log-level INFO

--- a/include/make/hugo.mk
+++ b/include/make/hugo.mk
@@ -28,6 +28,11 @@ run_hugo_%_tests_with_timeout:
 	>&2 echo "ERROR: Production site never came up."; \
 	exit 1;
 
+start_local_blog:
+	$(DOCKER_COMPOSE_RUN_COMMAND) generate-hugo-configs && \
+	$(DOCKER_COMPOSE_RUN_COMMAND) fetch-hugo-theme && \
+	$(DOCKER_COMPOSE_COMMAND) up hugo-server
+
 version_hugo_index_and_error_files:
 	export S3_BUCKET=$$($(DOCKER_COMPOSE_RUN_COMMAND) terraform output blog_bucket_name | tr -d $$'\r' | sed 's/index_html_file = //'); \
 	export INDEX_HTML_FILE=$$($(DOCKER_COMPOSE_RUN_COMMAND) terraform output index_html_name | tr -d $$'\r' | sed 's/index_html_file = //'); \


### PR DESCRIPTION
Previously, one had to clone bloggen and do all sorts of magic to get a local
blog up and running. This series of commits solves that problem by:

- Adding an environment variable, `HOST_PWD`, that allows users to expose
  their real working directories so that nested containers can access them, and

- Adding a minimal `alpine-bash-git` Dockerfile that can be used to spin up
  the bloggen.

The `README` was updated to reflect these changes.